### PR TITLE
New view for topic+image with credit tooltip

### DIFF
--- a/mods/wikirate/sets/right/wikirate_link.rb
+++ b/mods/wikirate/sets/right/wikirate_link.rb
@@ -6,7 +6,9 @@ view :core do |args|
   #site = site_card && site_card.item_names.first
   link_to "source page", card.raw_content, :target=>'source', :class=>'wikirate-source-link external-link'
 end
-
+view :editor do |args|
+  form.text_field :content, :class=>'card-content',:placeholder=>"http://example.com"
+end
 event :validate_content, :before=>:approve, :on=>:save do
   begin
     @host = nil

--- a/mods/wikirate/sets/type/webpage.rb
+++ b/mods/wikirate/sets/type/webpage.rb
@@ -34,7 +34,7 @@ end
 
 def find_duplicates url
   #need to check if content changed...
-  duplicate_wql = { :right=>Card[:wikirate_link].name, :content=>url }
+   duplicate_wql = { :right=>Card[:wikirate_link].name, :content=>url ,:left=>{:type_id=>Card::WebpageID}}
 #  duplicate_wql[:not] = { :id => id } if id
   duplicates = Card.search duplicate_wql
 end

--- a/mods/wikirate/sets/type/wikirate_topic.rb
+++ b/mods/wikirate/sets/type/wikirate_topic.rb
@@ -1,6 +1,6 @@
 view :missing do |args|
-  _render_link args
 end
+  _render_link args
 view :image do |args|
   #byebug
   image_card = Card.fetch("#{ card.name }+image")

--- a/mods/wikirate/sets/type/wikirate_topic.rb
+++ b/mods/wikirate/sets/type/wikirate_topic.rb
@@ -1,6 +1,7 @@
 view :missing do |args|
+    _render_link args
 end
-  _render_link args
+
 view :image do |args|
   #byebug
   image_card = Card.fetch("#{ card.name }+image")

--- a/mods/wikirate/sets/type/wikirate_topic.rb
+++ b/mods/wikirate/sets/type/wikirate_topic.rb
@@ -1,3 +1,18 @@
 view :missing do |args|
   _render_link args
 end
+view :image do |args|
+  #byebug
+  image_card = Card.fetch("#{ card.name }+image")
+  image_source_card = Card.fetch("#{ card.name }+image source")
+  image_url = ""
+  if image_card
+    image_url = image_card.format( :format=>:html)._render(:source) 
+  end
+  title = ""
+  if image_source_card
+    title = strip_tags image_source_card.content
+  end
+  %{<img src='#{image_url}' title='#{title}' />}
+
+end


### PR DESCRIPTION
I dont think this is a good approach. I tried to have {{+image|structure: topic image structure}} but it doesnt work. 

To keep the edit view showing the image and image source, I use 

```
{{_|image}}
  <div style=" display: none;" >{{+Image|float: left}}
  <div style="clear:both"></div>
  {{+Image source}}
</div>
```

Again, this approach is ugly and I am looking for better way. 
