### PR TITLE
fix permission showing problem in cliam reading page when not logged in

### DIFF
--- a/mod/wikirate/set/type/claim.rb
+++ b/mod/wikirate/set/type/claim.rb
@@ -28,7 +28,7 @@ format :html do
   
   view :tip do |args|
     # special view for prompting users with next steps
-    if ( tip = args[:tip] || next_step_tip ) and Auth.signed_in?
+    if Auth.signed_in? and ( tip = args[:tip] || next_step_tip ) 
       %{
         <div class="claim-tip">
           Tip: You can #{ tip }

--- a/mod/wikirate/set/type/claim.rb
+++ b/mod/wikirate/set/type/claim.rb
@@ -26,9 +26,9 @@ format :html do
   end
 
   
-  view :tip, :perms=>:update do |args|
+  view :tip do |args|
     # special view for prompting users with next steps
-    if tip = args[:tip] || next_step_tip
+    if ( tip = args[:tip] || next_step_tip ) and Auth.signed_in?
       %{
         <div class="claim-tip">
           Tip: You can #{ tip }

--- a/mod/wikirate/spec/mod/wikirate/spec_helper.rb
+++ b/mod/wikirate/spec/mod/wikirate/spec_helper.rb
@@ -1,0 +1,9 @@
+
+  def create_page iUrl=nil
+      url = iUrl||'http://www.google.com/?q=wikirateissocoolandawesomeyouknow'
+    Card::Env.params[:sourcebox] = 'true'
+    sourcepage = Card.create! :type_id=>Card::WebpageID,:subcards=>{ '+Link' => {:content=> url} }
+    Card::Env.params[:sourcebox] = 'false'
+
+    sourcepage
+  end


### PR DESCRIPTION
I removed the permission checking for the tip and add a checking whether the user logged in or not. I do not know whether there is a way to not show the error when the user do not have the permission, so I just added a sign in checking and returned empty.
