### PR TITLE
source link is needed to be converted from '&' to '&amp;' as links store...

### DIFF
--- a/mod/wikirate/set/all/wikirate.rb
+++ b/mod/wikirate/set/all/wikirate.rb
@@ -2,6 +2,10 @@
 require "net/https"
 require "uri"
 format do
+  def html_escape_except_quotes s
+    # to be used inside single quotes (makes for readable json attributes)
+    s.to_s.gsub(/&/, "&amp;").gsub(/\'/, "&apos;").gsub(/>/, "&gt;").gsub(/</, "&lt;")
+  end
   view :cite do |args|
     ''
   end
@@ -156,8 +160,8 @@ format :json do
     url = Card::Env.params[:url]
     result = {:result => false }
     if url
-      source = Self::Webpage.find_duplicates url
-      result[:source] = source.first.left.name if source.any?
+      source = Self::Webpage.find_duplicates html_escape_except_quotes(url)
+      result = {:result => true, :source => source.first.left.name} if source.any?
     end
     result.to_json
   end


### PR DESCRIPTION
source link is needed to be converted from '&' to '&amp;' as links stored are converted to '&amp;'. Query source page by url  will fail for this case.

There is no use to convert & to &amp; as there still a & in url which will cut the url when getting parameter url. 
