### PR TITLE
fixed iframable is not working on ruby<2.0

### DIFF
--- a/mod/wikirate/set/self/wikirate_source_preview_page.rb
+++ b/mod/wikirate/set/self/wikirate_source_preview_page.rb
@@ -167,7 +167,7 @@ format :json do
       # escape space in url, eg, http://www.businessweek.com/articles/2014-10-30/tim-cook-im-proud-to-be-gay#r=most popular
       url.gsub!(/ /, '%20')
       uri = open(url)
-      xFrameOptions = uri.metas["x-frame-options"]
+      xFrameOptions = uri.meta["x-frame-options"]
       return false if xFrameOptions and ( xFrameOptions.upcase.include? "DENY" or xFrameOptions.upcase.include? "SAMEORIGIN" )
       return false if uri.content_type != "text/html"
     rescue => error

--- a/mod/wikirate/spec/mod/wikirate/set/right/wikirate_link_spec.rb
+++ b/mod/wikirate/spec/mod/wikirate/set/right/wikirate_link_spec.rb
@@ -15,9 +15,9 @@ describe Card::Set::Right::Source do
 
     link_card.content = "http://www.google.com/"
 
-    link_card.save.should == false
-    link_card.errors.should have_key :link
-    link_card.errors[:link]=="is not allowed to be changed."
+    expect(link_card.save).to be false
+    expect(link_card.errors).to have_key(:link)
+    expect(link_card.errors[:link]).to include("is not allowed to be changed.")
 
   end
 


### PR DESCRIPTION
1. the `metas` on uri is not supported in ruby < 2.0. use `meta` instead
2. update one rspec case as `should` is suggested to be depreciated. 
