### PR TITLE
fix stack level too deep problem for claim's tip view

### DIFF
--- a/mod/wikirate/set/type/claim.rb
+++ b/mod/wikirate/set/type/claim.rb
@@ -73,7 +73,7 @@ format :html do
   end
 
   
-  view :tip, :perms=>:none do |args|
+  view :tip, :perms=>:none, :closed=>:blank do |args|
     # special view for prompting users with next steps
     if Auth.signed_in? and ( tip = args[:tip] || next_step_tip ) and @mode != :closed
       %{


### PR DESCRIPTION
claim structure card has`{_self|tip}`. tip view is not rendered in closed view so it will render the closed view again. 
