### PR TITLE
use a faster link

### DIFF
--- a/mod/wikirate_source/spec/set/type/source/source_preview_spec.rb
+++ b/mod/wikirate_source/spec/set/type/source/source_preview_spec.rb
@@ -81,7 +81,7 @@ describe Card::Set::Type::Source do
     end
     context "link source" do
       before do
-        @url = "http://newsource.com"
+        @url = 'http://wagn.org'
         @company = "Amazon.com, Inc."
         @topic = "Natural Resource Use"
         @existing_source = create_page_with_sourcebox @url,{"+Company"=>@company,"+Topic"=>@topic},'false'


### PR DESCRIPTION
I don't know why the curl on link `http://newsource.com` is very slow on semaphore. I tried with wagn website and the test finished in a few seconds.
