### PR TITLE
script to create gibs users

### DIFF
--- a/script/create_gibs_users.rb
+++ b/script/create_gibs_users.rb
@@ -1,0 +1,25 @@
+require File.expand_path('../../config/environment',  __FILE__)
+
+CSV.foreach('script/gist_users.csv', encoding: 'windows-1251:utf-8',
+                                     headers: true,
+                                     header_converters: :symbol) do |row|
+  Card::Auth.current_id = Card::AnonymousID
+  unless Card.exists? row[:name]
+    args = {
+      name: row[:name],
+      type_id: Card::SignupID,
+      '+*account' => {
+        '+*email' => 'wikirate@mailinator.com',
+        '+*password' => row[:password]
+      }
+    }
+    puts "account to be created: #{args}"
+    signup = Card.create! args
+    Card::Auth.as_bot
+    puts "activating #{row[:name]}"
+    signup.activate_account
+    puts "update email of #{row[:name]} to #{row[:email]}"
+    email_card = Card["#{row[:name]}+*account+*email"]
+    email_card.update_attributes! content: row[:email], silent_change: true
+  end
+end


### PR DESCRIPTION
Richard wants to create a bunch of users for gibs so I created this script.

As the CSV file contains the users' information, I will manually upload it to live/dev and run the script once it is deployed.

As we may not want the users receiving too many emails, so I redirect all email to a dummy email receiver service.  
