### PR TITLE
Fix url iframable check

### DIFF
--- a/mod/wikirate/spec/set/self/source_spec.rb
+++ b/mod/wikirate/spec/set/self/source_spec.rb
@@ -31,12 +31,12 @@ describe Card::Set::Self::Source do
     context "when rendering pdf in firefox" do 
       it "returns true if it is firefox" do 
         url = 'http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_open_parameters.pdf'
-        result = @page_card.format( :format=>:json).iframable? url,"Firefox"
+        result = @page_card.format(format: :json).iframable? url, 'Firefox'
         expect(result).to be(true)
       end
       it "returns false if it is not firefox" do 
         url = 'http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_open_parameters.pdf'
-        result = @page_card.format( :format=>:json).iframable? url,"Chrome"
+        result = @page_card.format(format: :json).iframable? url, 'Chrome'
         expect(result).to be(false)
       end
     end

--- a/mod/wikirate/spec/set/self/source_spec.rb
+++ b/mod/wikirate/spec/set/self/source_spec.rb
@@ -2,120 +2,109 @@
 require 'link_thumbnailer'
 
 describe Card::Set::Self::Source do
-   before do
-     @page_card = Card["Source"]
+  before do
+    @page_card = Card['Source']
   end
-  describe "while check iframable" do
-    it "should return true for a iframable website" do
-    
+  describe 'while check iframable' do
+    it 'should return true for a iframable website' do
       url = 'http://example.org'
-   
+
       Card::Env.params[:url] = url
-      result = @page_card.format( :format=>:json)._render(:check_iframable) 
+      result = @page_card.format(format: :json)._render(:check_iframable)
       expect(result[:result]).to be true
-      
+
       url = 'http://www.peri.umass.edu/toxicair_current/'
       Card::Env.params[:url] = url
-      result = @page_card.format( :format=>:json)._render(:check_iframable) 
+      result = @page_card.format(format: :json)._render(:check_iframable)
       expect(result[:result]).to be true
-
     end
 
-    it "should return false for non iframble website" do
+    it 'should return false for non iframble website' do
       url = 'http://www.google.com'
-      
+
       Card::Env.params[:url] = url
-      result = @page_card.format( :format=>:json)._render(:check_iframable) 
+      result = @page_card.format(format: :json)._render(:check_iframable)
       expect(result[:result]).to be false
     end
-    context "when rendering pdf in firefox" do 
-      it "returns true if it is firefox" do 
+    context 'when rendering pdf in firefox' do
+      it 'returns true if it is firefox' do
         url = 'http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_open_parameters.pdf'
         result = @page_card.format(format: :json).iframable? url, 'Firefox'
         expect(result).to be(true)
       end
-      it "returns false if it is not firefox" do 
+      it 'returns false if it is not firefox' do
         url = 'http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_open_parameters.pdf'
         result = @page_card.format(format: :json).iframable? url, 'Chrome'
         expect(result).to be(false)
       end
     end
-    
-    it "should return false for non sense website" do
+
+    it 'should return false for non sense website' do
       url = 'helloworld'
-      
+
       Card::Env.params[:url] = url
-      result = @page_card.format( :format=>:json)._render(:check_iframable) 
+      result = @page_card.format(format: :json)._render(:check_iframable)
       expect(result[:result]).to be false
     end
-    it "should return false for empty website" do
-      
-      result = @page_card.format( :format=>:json)._render(:check_iframable) 
+    it 'should return false for empty website' do
+      result = @page_card.format(format: :json)._render(:check_iframable)
       expect(result[:result]).to be false
     end
   end
- 
-  describe "get meta data of url" do
-    
-    it "handles invalid url" do
-      
+  describe 'get meta data of url' do
+    it 'handles invalid url' do
       url = 'abcdefg'
-      
+
       Card::Env.params[:url] = url
-      result = @page_card.format( :format=>:json)._render(:metadata) 
+      result = @page_card.format(format: :json)._render(:metadata)
 
       result_hash = JSON.parse(result)
-      expect(result_hash["title"]).to eq("")
-      expect(result_hash["description"]).to eq("")
-      expect(result_hash["error"]).to eq('invalid url')
-     
+      expect(result_hash['title']).to eq('')
+      expect(result_hash['description']).to eq('')
+      expect(result_hash['error']).to eq('invalid url')
     end
-    it "handles empty url" do
+    it 'handles empty url' do
       url = ''
-      
+
       Card::Env.params[:url] = url
-      result = @page_card.format( :format=>:json)._render(:metadata) 
+      result = @page_card.format(format: :json)._render(:metadata)
 
       result_hash = JSON.parse(result)
-      expect(result_hash["title"]).to eq("")
-      expect(result_hash["description"]).to eq("")
-      expect(result_hash["error"]).to eq('empty url')
+      expect(result_hash['title']).to eq('')
+      expect(result_hash['description']).to eq('')
+      expect(result_hash['error']).to eq('empty url')
     end
-
-    it "handles normal existing url " do
+    it 'handles normal existing url ' do
       url = 'http://www.google.com/?q=wikirateissocoolandawesomeyouknow'
-      sourcepage = create_page_with_sourcebox url,{},'true'
+      sourcepage = create_page_with_sourcebox url, {}, 'true'
 
-      
       Card::Env.params[:url] = url
-      result = @page_card.format( :format=>:json)._render(:metadata) 
+      result = @page_card.format(format: :json)._render(:metadata)
 
       result_hash = JSON.parse(result)
-      expect(Card.fetch("#{ sourcepage.name }+title").content).to eq result_hash["title"]
-      expect(Card.fetch("#{ sourcepage.name }+description").content).to eq result_hash["description"]
-      expect(result_hash["error"].empty?).to be true
+      source_page_content = Card.fetch("#{sourcepage.name}+title").content
+      expect(source_page_content).to eq result_hash['title']
+      source_page_desc = Card.fetch("#{sourcepage.name}+description").content
+      expect(source_page_desc).to eq result_hash['description']
+      expect(result_hash['error'].empty?).to be true
     end
-
-    it "handles normal non existing url " do
+    it 'handles normal non existing url ' do
       url = 'http://www.google.com/?q=wikirateissocoolandawesomeyouknow'
-      
-      
+
       Card::Env.params[:url] = url
-      result = @page_card.format( :format=>:json)._render(:metadata) 
+      result = @page_card.format(format: :json)._render(:metadata)
 
       result_hash = JSON.parse(result)
       preview = LinkThumbnailer.generate(url)
 
-      expect(result_hash["title"]).to eq(preview.title)
-      expect(result_hash["description"]).to eq(preview.description)
-      expect(result_hash["error"].empty?).to be true
-      
+      expect(result_hash['title']).to eq(preview.title)
+      expect(result_hash['description']).to eq(preview.description)
+      expect(result_hash['error'].empty?).to be true
     end
-
-    it "shows the link for view \"missing\"" do
-      sourcepage = create_page_with_sourcebox nil,{},'true'
-      html = render_card :missing,{:name=>sourcepage.name}
-      expect(html).to eq(render_card :link,{:name=>sourcepage.name} )
+    it 'shows the link for view "missing"' do
+      sourcepage = create_page_with_sourcebox nil, {}, 'true'
+      html = render_card :missing, name: sourcepage.name
+      expect(html).to eq(render_card(:link, name: sourcepage.name))
     end
   end
 end

--- a/mod/wikirate/spec/set/self/source_spec.rb
+++ b/mod/wikirate/spec/set/self/source_spec.rb
@@ -31,12 +31,12 @@ describe Card::Set::Self::Source do
     context "when rendering pdf in firefox" do 
       it "returns true if it is firefox" do 
         url = 'http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_open_parameters.pdf'
-        result = @page_card.format( :format=>:json).is_iframable? url,"Firefox"
+        result = @page_card.format( :format=>:json).iframable? url,"Firefox"
         expect(result).to be(true)
       end
       it "returns false if it is not firefox" do 
         url = 'http://www.adobe.com/content/dam/Adobe/en/devnet/acrobat/pdfs/pdf_open_parameters.pdf'
-        result = @page_card.format( :format=>:json).is_iframable? url,"Chrome"
+        result = @page_card.format( :format=>:json).iframable? url,"Chrome"
         expect(result).to be(false)
       end
     end
@@ -54,115 +54,7 @@ describe Card::Set::Self::Source do
       expect(result[:result]).to be false
     end
   end
-  # unblock until source suggestion is back
-  # describe "send feedback to CERTH" do
-  #   before do
-  #     @url = "http://google.com"
-  #   end
-  #   describe "send insufficient parameters" do
-  #     it "handles no parameter" do 
-  #       #no parameters
-  #       result = @page_card.format( :format=>:json)._render(:feedback)
-  #       expect(result[:result]).to be false
-  #     end
-  #     it "handles no url" do
-  #       Card::Env.params[:company] = "Apple Inc."
-  #       Card::Env.params[:topic] = "Natural Resource Use"
-  #       Card::Env.params[:type] = "either"
-  #       result = @page_card.format( :format=>:json)._render(:feedback)
-  #       expect(result[:result]).to be false
-
-  #     end
-  #     it "handles no company" do
-  #      Card::Env.params[:url] = @url
-  #       Card::Env.params[:topic] = "Natural Resource Use"
-  #       Card::Env.params[:type] = "either"
-  #       result = @page_card.format( :format=>:json)._render(:feedback)
-  #       expect(result[:result]).to be false
-
-  #     end
-  #     it "handles no topic" do
-  #       Card::Env.params[:url] = @url
-  #       Card::Env.params[:company] = "Apple Inc."
-  #       Card::Env.params[:type] = "either"
-  #       result = @page_card.format( :format=>:json)._render(:feedback)
-  #       expect(result[:result]).to be false
-
-  #     end
-  #     it "handles no type" do
-  #       Card::Env.params[:url] = @url
-  #       Card::Env.params[:company] = "Apple Inc."
-  #       Card::Env.params[:topic] = "Natural Resource Use"
-  #       result = @page_card.format( :format=>:json)._render(:feedback)
-  #       expect(result[:result]).to be false
-
-  #     end
-  #   end
-  #   describe "send invalid parameters" do
-  #     it "handles invalid company" do 
-  #       Card::Env.params[:url] = @url
-  #       Card::Env.params[:company] = "joe_user"
-  #       Card::Env.params[:topic] = "Natural Resource Use"
-  #       Card::Env.params[:type] = "either"
-  #       result = @page_card.format( :format=>:json)._render(:feedback)
-  #       expect(result[:result]).to be false
-  #     end
-  #     it "handles invalid topic" do 
-  #       Card::Env.params[:url] = @url
-  #       Card::Env.params[:company] = "Apple Inc."
-  #       Card::Env.params[:topic] = "joe_user"
-  #       Card::Env.params[:type] = "either"
-  #       result = @page_card.format( :format=>:json)._render(:feedback)
-  #       expect(result[:result]).to be false
-  #     end
-  #     it "handles invalid type" do 
-  #       Card::Env.params[:url] = @url
-  #       Card::Env.params[:company] = "Apple Inc."
-  #       Card::Env.params[:topic] = "Natural Resource Use"
-  #       Card::Env.params[:type] = "joe_user"
-  #       result = @page_card.format( :format=>:json)._render(:feedback)
-  #       expect(result[:result]).to be false
-  #     end
-  #   end
-  #   describe "normal cases" do
-  #     it "handles either type" do 
-  #       Card::Env.params[:url] = @url
-  #       Card::Env.params[:company] = "Apple Inc."
-  #       Card::Env.params[:topic] = "Natural Resource Use"
-  #       Card::Env.params[:type] = "either"
-  #       result = @page_card.format( :format=>:json)._render(:feedback)
-  #       expect(result[:result]).to be true
-  #       expect(result[:result_from_certh]).to eq(1)
-  #     end
-  #     it "handles company type" do 
-  #       Card::Env.params[:url] = @url
-  #       Card::Env.params[:company] = "Apple Inc."
-  #       Card::Env.params[:topic] = "Natural Resource Use"
-  #       Card::Env.params[:type] = "company"
-  #       result = @page_card.format( :format=>:json)._render(:feedback)
-  #       expect(result[:result]).to be true
-  #       expect(result[:result_from_certh]).to eq(1)
-  #     end
-  #     it "handles topic type" do 
-  #       Card::Env.params[:url] = @url
-  #       Card::Env.params[:company] = "Apple Inc."
-  #       Card::Env.params[:topic] = "Natural Resource Use"
-  #       Card::Env.params[:type] = "topic"
-  #       result = @page_card.format( :format=>:json)._render(:feedback)
-  #       expect(result[:result]).to be true
-  #       expect(result[:result_from_certh]).to eq(1)
-  #     end
-  #     it "handles relevant type" do 
-  #       Card::Env.params[:url] = @url
-  #       Card::Env.params[:company] = "Apple Inc."
-  #       Card::Env.params[:topic] = "Natural Resource Use"
-  #       Card::Env.params[:type] = "relevant"
-  #       result = @page_card.format( :format=>:json)._render(:feedback)
-  #       expect(result[:result]).to be true
-  #       expect(result[:result_from_certh]).to eq(1)
-  #     end
-  #   end
-  # end
+ 
   describe "get meta data of url" do
     
     it "handles invalid url" do

--- a/mod/wikirate_source/set/self/source.rb
+++ b/mod/wikirate_source/set/self/source.rb
@@ -12,12 +12,12 @@ format :json do
       metadata.error = 'empty url'
       return metadata.to_json
     end
-    begin      
+    begin  
       metadata.website = URI(url).host
-    rescue    
+    rescue
     end
     if !metadata.website
-      metadata.error = 'invalid url' 
+      metadata.error = 'invalid url'
       return metadata.to_json
     end
     duplicates = Source.find_duplicates url
@@ -28,7 +28,7 @@ format :json do
       image_url = Card["#{origin_page_card.name}+image_url"] ? Card["#{origin_page_card.name}+image_url"].content : ""
       metadata.set_meta_data title,description,image_url
     else
-      begin 
+      begin
         preview = LinkThumbnailer.generate url
         if preview.images.length > 0
           image_url = preview.images.first.src.to_s
@@ -86,7 +86,6 @@ format :json do
     end
     true
   end
-  
   view :check_iframable do |_args|
     url = Card::Env.params[:url]
     if url
@@ -117,5 +116,4 @@ class MetaData
     @description = desc
     @image_url = image_url
   end
-end  
-
+end

--- a/mod/wikirate_source/set/self/source.rb
+++ b/mod/wikirate_source/set/self/source.rb
@@ -12,12 +12,12 @@ format :json do
       metadata.error = 'empty url'
       return metadata.to_json
     end
-    begin
+    begin      
       metadata.website = URI(url).host
-    rescue
+    rescue    
     end
     if !metadata.website
-      metadata.error = 'invalid url'
+      metadata.error = 'invalid url' 
       return metadata.to_json
     end
     duplicates = Source.find_duplicates url
@@ -28,7 +28,7 @@ format :json do
       image_url = Card["#{origin_page_card.name}+image_url"] ? Card["#{origin_page_card.name}+image_url"].content : ""
       metadata.set_meta_data title,description,image_url
     else
-      begin
+      begin 
         preview = LinkThumbnailer.generate url
         if preview.images.length > 0
           image_url = preview.images.first.src.to_s
@@ -39,108 +39,83 @@ format :json do
     end
     metadata.to_json
   end
-  def valid_content_type? content_type
-    allow_content_type = ["image/png","image/jpeg"]
+  def valid_content_type? content_type, user_agent
+    allow_content_type = ['image/png', 'image/jpeg']
     # for case, "text/html; charset=iso-8859-1"
-    allow_content_type.include?(content_type) || content_type.start_with?("text/html") || content_type.start_with?("text/plain")
+    allow_content_type.include?(content_type) ||
+      content_type.start_with?('text/html') ||
+      content_type.start_with?('text/plain') ||
+      firefox?(user_agent)
   end
-  def is_iframable? url, user_agent
 
-    return false if !url or url.length == 0
+  def invalid_x_frame_options? options
+    options &&
+      (options.upcase.include?('DENY') ||
+      options.upcase.include?('SAMEORIGIN'))
+  end
+
+  def iframable_options url
+    # escape space in url, eg,
+    # http://www.businessweek.com/articles/2014-10-30/
+    # tim-cook-im-proud-to-be-gay#r=most popular
+    url.gsub!(/ /, '%20')
+    curl = Curl::Easy.new(url)
+    curl.follow_location = true
+    curl.max_redirects = 5
+    curl.http_head
+    header_str = curl.header_str
+    [header_str[/.*X-Frame-Options: (.*)\r\n/, 1],
+     header_str[/.*Content-Type: (.*)\r\n/, 1]]
+  end
+
+  def firefox? user_agent
+    user_agent ? user_agent =~ /Firefox/ : false
+  end
+
+  def iframable? url, user_agent
+    return false if !url || url.empty?
     begin
-      # escape space in url, eg, http://www.businessweek.com/articles/2014-10-30/tim-cook-im-proud-to-be-gay#r=most popular
-      url.gsub!(/ /, '%20')
-
-      curl = Curl::Easy.new(url)
-      curl.follow_location = true
-      curl.max_redirects = 5
-      curl.http_head
-      xFrameOptions = curl.head[/.*X-Frame-Options: (.*)\r\n/,1]
-      content_type = curl.head[/.*Content-Type: (.*)\r\n/,1]
-      is_firefox = user_agent ? user_agent =~ /Firefox/ : false
-      return false if xFrameOptions and ( xFrameOptions.upcase.include? "DENY" or xFrameOptions.upcase.include? "SAMEORIGIN" )
-      return false if !valid_content_type?(content_type) and  !is_firefox
+      x_frame_options, content_type = iframable_options url
+      if invalid_x_frame_options?(x_frame_options) ||
+         !valid_content_type?(content_type, user_agent)
+        return false
+      end
     rescue => error
       Rails.logger.error error.message
       return false
     end
     true
   end
-
-  view :check_iframable do |args|
+  
+  view :check_iframable do |_args|
     url = Card::Env.params[:url]
     if url
-      result = {:result => is_iframable?( url, request ? request.env['HTTP_USER_AGENT'] : nil ) }
+      iframe =
+        iframable?(url, request ? request.env['HTTP_USER_AGENT'] : nil)
+      result = { result: iframe }
     else
-      result = {:result => false }
+      result = { result: false }
     end
     result
   end
-
-#   uncomment until certh's suggestion is back
-#   view :feedback ,:perms=>lambda { |r| Auth.signed_in? } do |args|
-#     url = Card::Env.params[:url]
-#     company = Card::Env.params[:company]
-#     topic = Card::Env.params[:topic]
-
-#     type = Card::Env.params[:type]
-
-#     result = {:result => false }
-#     case type
-#     when "either"
-#       rel_topic_score = -1
-#       rel_company_score = -1
-#     when "company"
-#       rel_topic_score = 1
-#       rel_company_score = -1
-#     when "topic"
-#       rel_topic_score = -1
-#       rel_company_score = 1
-#     when "relevant"
-#       rel_topic_score = 1
-#       rel_company_score = 1
-#     else
-#       return result
-#     end
-#     user_id = Auth.current_id
-#     company_id, company_name = Card[company].id, Card[company].name if Card[company] and Card[company].type_id == Card::WikirateCompanyID
-#     topic_id, topic_name = Card[topic].id, Card[topic].name if Card[topic] and Card[topic].type_id == Card::WikirateTopicID
-
-#     if company_id and topic_id and url and type
-#       query = { url: url,
-#                 user_id: user_id,
-#                 rel_topic_score: rel_topic_score,
-#                 rel_company_score: rel_company_score,
-#                 company_id: company_id,
-#                 company: company_name,
-#                 topic_id: topic_id,
-#                 topic: topic_name}
-#                 .to_query
-#       request_url = "http://mklab.iti.gr/wikirate-sandbox/api/index.php/relevance/?#{query}"
-#       uri = URI.parse(request_url)
-#       http = Net::HTTP.new(uri.host, uri.port)
-#       request = Net::HTTP::Get.new(uri.request_uri)
-#       response = http.request(request)
-#       result_from_certh = JSON.parse(response.body)
-#       #TODO: log them to a file
-#       result = {:result => true, :result_from_certh => result_from_certh["results"]["code"],:msg=>result_from_certh["results"]["msg"]}
-#     end
-#     result
-#   end
 end
 
+# hash result for iframe checking
 class MetaData
-  attr_accessor :title,:description,:image_url,:website,:error
-  def initialize()
-    @title = ""
-    @description = ""
-    @image_url  =""
-    @website = ""
-    @error = ""
+  attr_accessor :title, :description, :image_url, :website, :error
+
+  def initialize
+    @title = ''
+    @description = ''
+    @image_url = ''
+    @website = ''
+    @error = ''
   end
-  def set_meta_data title,desc,image_url
+
+  def set_meta_data title, desc, image_url
     @title = title
     @description = desc
     @image_url = image_url
   end
-end
+end  
+

--- a/mod/wikirate_source/set/source_type/wikirate_link.rb
+++ b/mod/wikirate_source/set/source_type/wikirate_link.rb
@@ -106,12 +106,12 @@ rescue  # if open raises errors , just treat the source as a normal source
   Rails.logger.info 'Fail to get the file from link'
 end
 
-def get_curl url
+def get_header url
   curl = Curl::Easy.new(url)
   curl.follow_location = true
   curl.max_redirects = 5
   curl.http_head
-  curl
+  curl.header_str
 end
 
 def max_size
@@ -121,9 +121,9 @@ end
 
 def file_type_and_size url
   # just got the header instead of downloading the whole file
-  curl = get_curl(url)
-  content_type = curl.head[/.*Content-Type: (.*)\r\n/, 1]
-  content_size = curl.head[/.*Content-Length: (.*)\r\n/, 1].to_i
+  header_str = get_header(url)
+  content_type = header_str[/.*Content-Type: (.*)\r\n/, 1]
+  content_size = header_str[/.*Content-Length: (.*)\r\n/, 1].to_i
   [content_type, content_size]
 rescue
   Rails.logger.info "Fail to extract header from the #{url}"


### PR DESCRIPTION
`curl.head` is returning `nil`. 
However, in raw ruby console and test environment, it is returning correct http header string.

`curl.header_str` is working fine and is used to replace `curl.head`.
