### PR TITLE
update values if variable is used in formula

### DIFF
--- a/mod/01_rating/set/type_plus_right/metric/formula.rb
+++ b/mod/01_rating/set/type_plus_right/metric/formula.rb
@@ -274,7 +274,6 @@ def input_metric_keys
 end
 
 def input_metrics
-  binding.pry
   @input_metrics ||= extract_metrics
 end
 

--- a/mod/01_rating/set/type_plus_right/metric/formula.rb
+++ b/mod/01_rating/set/type_plus_right/metric/formula.rb
@@ -60,11 +60,7 @@ def complete_translation_table
 end
 
 def variables_card
-  v_card = metric_card.fetch trait: :variables,
-        new: {
-          type: 'session',
-          content: input_metrics.to_pointer_content
-        }
+  v_card = metric_card.fetch trait: :variables, new: { type: 'session' }
   if v_card.content.blank?
     v_card.content = input_metrics.to_pointer_content
   end
@@ -278,6 +274,7 @@ def input_metric_keys
 end
 
 def input_metrics
+  binding.pry
   @input_metrics ||= extract_metrics
 end
 


### PR DESCRIPTION
input_metrics was called on every variables card fetch. If the formula has variable names in it that causes bad content in @input_metrics
