### PR TITLE
handle extra space of url, and file blocked by cloud front

### DIFF
--- a/mod/wikirate_source/set/source_type/wikirate_link.rb
+++ b/mod/wikirate_source/set/source_type/wikirate_link.rb
@@ -91,7 +91,7 @@ def get_card url
   if wikirate_url?(url)
     # try to convert the link to source card,
     # easier for users to add source in +source editor
-    uri = URI.parse(URI.unescape(url))
+    uri = URI.parse(URI.unescape(url.strip))
     Card[uri.path]
   else
     Card[url]
@@ -124,7 +124,8 @@ end
 def file_type_and_size url
   # just got the header instead of downloading the whole file
   header_str = get_header(url)
-  content_type = header_str[/.*Content-Type: (.*)\r\n/, 1]
+  # error won't give us content type, treat it as a normal link
+  content_type = header_str[/.*Content-Type: (.*)\r\n/, 1] || ''
   content_size = header_str[/.*Content-Length: (.*)\r\n/, 1].to_i
   [content_type, content_size]
 rescue => error

--- a/mod/wikirate_source/set/source_type/wikirate_link.rb
+++ b/mod/wikirate_source/set/source_type/wikirate_link.rb
@@ -61,6 +61,7 @@ event :process_source_url, after: :check_source,
     errors.add(:link, 'does not exist.')
     return
   end
+  link_card.content.strip!
   url = link_card.content
   handle_source_box_source url if Card::Env.params[:sourcebox] == 'true'
   duplication_check url
@@ -91,7 +92,7 @@ def get_card url
   if wikirate_url?(url)
     # try to convert the link to source card,
     # easier for users to add source in +source editor
-    uri = URI.parse(URI.unescape(url.strip))
+    uri = URI.parse(URI.unescape(url))
     Card[uri.path]
   else
     Card[url]


### PR DESCRIPTION
1. curl fails to fetch header of http://www.angloamerican.com/~/media/Files/A/Anglo-American-PLC-V2/documents/aa-sdreport-2015.pdf and causing problem while we try to get the content type.
2. remove extra space in the url
