### PR TITLE
fix fetch fail while lvy is number

### DIFF
--- a/mod/01_rating/set/ltype_rtype/metric/wikirate_company.rb
+++ b/mod/01_rating/set/ltype_rtype/metric/wikirate_company.rb
@@ -4,7 +4,7 @@ end
 
 def latest_value_card
   return if !(lvy = latest_value_year) || lvy == 0
-  Card.fetch cardname, lvy
+  Card.fetch cardname, lvy.to_s
 end
 
 def company_card

--- a/mod/wikirate/config/initializers/inflections.rb
+++ b/mod/wikirate/config/initializers/inflections.rb
@@ -1,0 +1,7 @@
+# -*- encoding : utf-8 -*-
+# Be sure to restart your server when you modify this file.
+
+# Add new inflection rules using the following format
+ActiveSupport::Inflector.inflections do |inflect|
+  inflect.uncountable "siemen"
+end


### PR DESCRIPTION
fetch fails to get correct card here if `lvy` is a number but not string
