### PR TITLE
prevent import from blocking the site

### DIFF
--- a/mod/wikirate/set/abstract/import.rb
+++ b/mod/wikirate/set/abstract/import.rb
@@ -12,6 +12,11 @@ event :import_csv, :prepare_to_store,
     metric_value_card.director.catch_up_to_stage :validate if metric_value_card
     handle_import_errors metric_value_card
   end
+  if errors.empty?
+    # create the metric values
+    subcards.each(&:save!)
+    clear_subcards
+  end
   handle_redirect
 end
 

--- a/mod/wikirate/set/abstract/import.rb
+++ b/mod/wikirate/set/abstract/import.rb
@@ -12,12 +12,12 @@ event :import_csv, :prepare_to_store,
     metric_value_card.director.catch_up_to_stage :validate if metric_value_card
     handle_import_errors metric_value_card
   end
+  handle_redirect
   if errors.empty?
     # create the metric values
     subcards.each(&:save!)
     clear_subcards
   end
-  handle_redirect
 end
 
 def check_duplication name, row_no


### PR DESCRIPTION
I guess if metric values are created using standard stage way, all things will be bonded in one transaction which will block the tables until all metric values are created. 
