### PR TITLE
fix migration issue

### DIFF
--- a/db/migrate/20170524163430_add_editor_id_to_answer_table.rb
+++ b/db/migrate/20170524163430_add_editor_id_to_answer_table.rb
@@ -2,6 +2,6 @@
 
 class AddEditorIdToAnswerTable < Card::Migration::DeckStructure
   def up
-    add_column :answers, :editor_id, :integer
+    # add_column :answers, :editor_id, :integer
   end
 end

--- a/mod/badges/set/abstract/answer_create_affinity_badge.rb
+++ b/mod/badges/set/abstract/answer_create_affinity_badge.rb
@@ -12,7 +12,7 @@ format :html do
   delegate :affinity, :affinity_card, :affinity_type, :badge, to: :card
 
   view :badge, tags: :unknown_ok do
-    voo.title  =
+    voo.title =
       if affinity_type == :designer
         "Metric Designer"
       else

--- a/mod/badges/set/abstract/answer_create_affinity_badge.rb
+++ b/mod/badges/set/abstract/answer_create_affinity_badge.rb
@@ -12,13 +12,13 @@ format :html do
   delegate :affinity, :affinity_card, :affinity_type, :badge, to: :card
 
   view :badge, tags: :unknown_ok do
-    type_name =
+    voo.title  =
       if affinity_type == :designer
         "Metric Designer"
       else
         affinity_type.to_s.capitalize
       end
-    nest affinity_card, view: :thumbnail, text: type_name
+    nest affinity_card, view: :thumbnail
   end
 
   view :level do

--- a/mod/metrics/set/right/variables.rb
+++ b/mod/metrics/set/right/variables.rb
@@ -16,9 +16,13 @@ end
 
 def content
   @content ||=
-    db_content.present? ? db_content : formula_card.input_names.to_pointer_content
+    db_content.present? ? db_content : variables_in_use.to_pointer_content
   # db_content should only be present when it has been set by a `card[content]`
   # parameter. the variable card is not intended to be saved.
+end
+
+def variables_in_use
+  formula_card&.input_names || []
 end
 
 def input_metric_name variable


### PR DESCRIPTION
Because the deck structure migrations have now there own table they run again. 
The hacky solution is to comment them out so that they get marked as migrated and then uncomment them.