### PR TITLE
rename overriding border-color variable

### DIFF
--- a/mod/wikirate/lib/stylesheets/style_wikirate_bootstrap_form.scss
+++ b/mod/wikirate/lib/stylesheets/style_wikirate_bootstrap_form.scss
@@ -1,7 +1,7 @@
 
 
 $brand-primary: #03998d !default; // #337ab7
-$border-color: #ccc;
+$form-input-border-color: #ccc;
 
 .form-control,
 input,
@@ -10,7 +10,7 @@ textarea {
     background-color: #fff;
     background-image: none;
     border-radius: 0;
-    border: 1px solid $border-color;
+    border: 1px solid $form-input-border-color;
     color: #555;
     // display: block;
     // font-size: 14px;


### PR DESCRIPTION
table borders seem odd and found out a border colour variable from another file was overriding the theme variables. 