### PR TITLE
Clipboard for Chrome, Safari, and Firefox

### DIFF
--- a/mod/deckorate_attribution/assets/script/clipboard.js.coffee
+++ b/mod/deckorate_attribution/assets/script/clipboard.js.coffee
@@ -33,7 +33,7 @@ copyRichOrPlainText = (html, text) ->
   $(document).off 'copy', listener
 
 $ ->
-  $("body").on "click", ".copy-button", ->
+  $("body").on "click", "._copy-button", ->
     copyHtmlToClipboard.call(this)
     activeTab = $(this).closest(".tab-pane.active")
     content = activeTab.find("._clipboard").html()

--- a/mod/deckorate_attribution/assets/script/clipboard.js.coffee
+++ b/mod/deckorate_attribution/assets/script/clipboard.js.coffee
@@ -1,6 +1,30 @@
-copyRichOrPlainText = (text) ->
+selectElementContents = (el) ->
+  range = document.createRange()
+  range.selectNode(el)
+  sel = window.getSelection()
+  sel.removeAllRanges()
+  sel.addRange(range)
+
+copyHtmlToClipboard = () -> 
+  activeTab = $(this).closest(".tab-pane.active")
+  dataHtmlElement = activeTab.find("._clipboard")[0]
+
+  if dataHtmlElement
+    dataHtmlElement.contentEditable = true
+    dataHtmlElement.readOnly = false
+
+    selectElementContents(dataHtmlElement)
+    copyRichOrPlainText(dataHtmlElement.innerHTML, dataHtmlElement.textContent)
+    dataHtmlElement.contentEditable = false
+    dataHtmlElement.readOnly = true
+
+    window.getSelection().removeAllRanges()
+  else
+    console.error("No ._clipboard element found in the active tab.")
+
+copyRichOrPlainText = (html, text) ->
   listener = (ev) ->
-    ev.originalEvent.clipboardData.setData('text/html', text)
+    ev.originalEvent.clipboardData.setData('text/html', html)
     ev.originalEvent.clipboardData.setData('text/plain', text)
     ev.preventDefault()
 
@@ -10,6 +34,7 @@ copyRichOrPlainText = (text) ->
 
 $ ->
   $("body").on "click", ".copy-button", ->
-    content = $(this).closest(".tab-pane.active").find("._clipboard").html()
-    copyRichOrPlainText(content)
+    copyHtmlToClipboard.call(this)
+    activeTab = $(this).closest(".tab-pane.active")
+    content = activeTab.find("._clipboard").html()
     console.info "Text copied to clipboard: #{content}"

--- a/mod/deckorate_attribution/assets/script/clipboard.js.coffee
+++ b/mod/deckorate_attribution/assets/script/clipboard.js.coffee
@@ -1,10 +1,15 @@
+copyRichOrPlainText = (text) ->
+  listener = (ev) ->
+    ev.originalEvent.clipboardData.setData('text/html', text)
+    ev.originalEvent.clipboardData.setData('text/plain', text)
+    ev.preventDefault()
+
+  $(document).on 'copy', listener
+  document.execCommand('copy')
+  $(document).off 'copy', listener
+
 $ ->
   $("body").on "click", ".copy-button", ->
     content = $(this).closest(".tab-pane.active").find("._clipboard").html()
-    blob = new Blob([content], { type: "text/html" });
-    richTextInput = new ClipboardItem({ "text/html": blob });
-    navigator.clipboard.write([richTextInput])
-      .then ->
-        console.log "Text copied to clipboard: #{content}"
-      .catch (error) ->
-        console.error "Copy to clipboard failed:", error
+    copyRichOrPlainText(content)
+    console.info "Text copied to clipboard: #{content}"

--- a/mod/deckorate_attribution/set/type/reference/attribution_box.haml
+++ b/mod/deckorate_attribution/set/type/reference/attribution_box.haml
@@ -1,7 +1,7 @@
 .d-flex.mb-3.align-items-stretch
   .p.clipboard._clipboard.p-2.rounded-start.flex-fill
     = content
-  %button.copy-button.btn.btn-primary{ type: "button", "data-bs-toggle": "button" }
+  %button.copy-button._copy-button.btn.btn-primary{ type: "button", "data-bs-toggle": "button" }
     .d-flex.fw-bold
       .pe-1
         Copy


### PR DESCRIPTION
Clipboard for all browsers and all text formats. Hyperlinks are preserved and content can be pasted in IDEs, etc as well as Word documents, etc. 