### PR TITLE
Wikipedia companies

### DIFF
--- a/mod/deckorate_graphql/lib/graph_q_l/types/company.rb
+++ b/mod/deckorate_graphql/lib/graph_q_l/types/company.rb
@@ -4,6 +4,7 @@ module GraphQL
     class Company < DeckorateCard
       field :headquarters, String, null: true
       field :wikipedia, String, null: true
+      field :official_company_website, String, null: true
       field :open_corporates, String, null: true
       field :sec_cik, String, null: true
       field :os_id, String, null: true

--- a/mod/wikirate_companies/data/real.yml
+++ b/mod/wikirate_companies/data/real.yml
@@ -32,6 +32,8 @@
   :codename: ilo_region
 - :name: Headquarters
   :codename: headquarters
+- :name: Official Company Website
+  :codename: official_company_website
 - :name:
     - Core
     - :country


### PR DESCRIPTION
Creates an official company website card. Disregard if this is not the route we want to take.